### PR TITLE
Fix fileimagelayer error when making migrations

### DIFF
--- a/pages/products/migrations/0005_productpage_map_layers.py
+++ b/pages/products/migrations/0005_productpage_map_layers.py
@@ -7,7 +7,6 @@ import wagtail.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('products', '0004_alter_productitempage_products'),
     ]
@@ -16,6 +15,10 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='productpage',
             name='map_layers',
-            field=wagtail.fields.StreamField([('layers', wagtail.blocks.StructBlock([('name', wagtail.blocks.CharBlock(required=False)), ('geomanager_layer', pages.products.models.UUIDModelChooserBlock(target_model='geomanager.fileimagelayer'))], label='Layer'))], blank=True, null=True, use_json_field=True, verbose_name='Map Layers'),
+            field=wagtail.fields.StreamField([('layers', wagtail.blocks.StructBlock(
+                [('name', wagtail.blocks.CharBlock(required=False)), ('geomanager_layer',
+                                                                      pages.products.models.UUIDModelChooserBlock(
+                                                                          target_model='geomanager.rasterfilelayer'))],
+                label='Layer'))], blank=True, null=True, use_json_field=True, verbose_name='Map Layers'),
         ),
     ]

--- a/pages/products/migrations/0006_alter_productpage_map_layers.py
+++ b/pages/products/migrations/0006_alter_productpage_map_layers.py
@@ -7,7 +7,6 @@ import wagtail.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('products', '0005_productpage_map_layers'),
     ]
@@ -16,6 +15,13 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='productpage',
             name='map_layers',
-            field=wagtail.fields.StreamField([('layers', wagtail.blocks.StructBlock([('geomanager_layer', pages.products.models.UUIDModelChooserBlock(target_model='geomanager.fileimagelayer')), ('product_type', wagtail.blocks.ChoiceBlock(choices=[], required=False))], label='Layer'))], blank=True, null=True, use_json_field=True, verbose_name='Map Layers'),
+            field=wagtail.fields.StreamField([('layers', wagtail.blocks.StructBlock([('geomanager_layer',
+                                                                                      pages.products.models.UUIDModelChooserBlock(
+                                                                                          target_model='geomanager.rasterfilelayer')),
+                                                                                     ('product_type',
+                                                                                      wagtail.blocks.ChoiceBlock(
+                                                                                          choices=[], required=False))],
+                                                                                    label='Layer'))], blank=True,
+                                             null=True, use_json_field=True, verbose_name='Map Layers'),
         ),
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ fonttools==4.39.4
 forecastmanager==0.2.0
 frozenlist==1.3.3
 future==0.18.3
-geomanager==0.1.6
+geomanager==0.1.7
 geopandas==0.13.0
 google-api-core==2.11.0
 google-api-python-client==2.79.0


### PR DESCRIPTION
### Fixes

- Fixes `LookupError: App 'geomanager' doesn't have a 'fileimagelayer' model.`

### Updates

- Update geomanager version
