### PR TITLE
Initial implementation for setting CMS version in code

### DIFF
--- a/base/templates/admin/cms_upgrade_notification.html
+++ b/base/templates/admin/cms_upgrade_notification.html
@@ -1,32 +1,20 @@
 {% load i18n wagtailadmin_tags %}
-<div id="w-cms-upgrade" class="w-panel-cms-upgrade panel w-hidden" data-cms-current-version="{{ current_version }}">
-    <div class="help-block help-warning">
-        {% icon name='warning' %}
-        {% translate "CMS upgrade available. Your version:" %} <strong>{{ current_version }}</strong>
-        {% translate "Latest version:" %} <strong id="w-cms-latest-version"></strong>.
-        {% if version_upgrade_url %}
-            <a href="{{ version_upgrade_url }}">{% translate "Upgrade" %}</a>
-        {% endif %}
-    </div>
-</div>
 
-<script>
-    const latestReleaseUrl = "{{ latest_release_url }}";
-    $(document).ready(function () {
-        const $cmsUpgrade = $("#w-cms-upgrade")
-        const $cmsLatestVersion = $("#w-cms-latest-version")
-        const currentVersion = $cmsUpgrade.data("cmsCurrentVersion")
-        if (currentVersion && latestReleaseUrl) {
-            fetch(latestReleaseUrl).then(res => res.json()).then(releaseData => {
-                const latestVersion = releaseData.name && releaseData.name.replace(/^v+|v+$/gi, '')
-                if (latestVersion && currentVersion !== latestVersion) {
-                    $cmsLatestVersion.text(latestVersion)
-                    $cmsUpgrade.show()
-                }
-            }).catch(err => {
-                console.log(err)
-            })
-        }
-    })
-</script>
+{% if cms_upgrade_hook_url and has_new_version %}
+    <div class="w-panel-cms-upgrade panel" data-cms-current-version="{{ current_version }}">
+        <div class="help-block help-warning">
+            {% icon name='warning' %}
+            {% translate "CMS upgrade available. Your version:" %} <strong>{{ current_version }}. </strong>
+            {% translate "Latest version:" %} <strong id="w-cms-latest-version">{{ latest_release.version }}</strong>.
+            {% if version_upgrade_url %}
+                <a href="{{ version_upgrade_url }}">{% translate "Upgrade" %}.</a>
+            {% endif %}
+        </div>
+    </div>
+
+
+{% endif %}
+
+
+
 

--- a/base/templates/admin/cms_version.html
+++ b/base/templates/admin/cms_version.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% load l10n %}
-{% load wagtailadmin_tags wagtailimages_tags static %}
+{% load wagtailadmin_tags wagtailimages_tags static nmhs_cms_tags %}
 {% block titletag %}
     {% blocktranslate trimmed with title=page.get_admin_display_title %}
         {{ title }}
@@ -35,77 +35,89 @@
     {% include "wagtailadmin/shared/header.html" with title=header_str icon="cog" %}
 
     <div class="nice-padding">
-
-        {% if current_version %}
-            <div class="v-item">{% translate "Current installed version" %}: <strong>{{ current_version }}</strong>
-            </div>
-        {% endif %}
-
-        {% if latest_release %}
-            <div class="v-item">
-                {% translate "Latest available version" %}:
-                <strong>{{ latest_release.version }}</strong></div>
-        {% endif %}
-
-        {% if current_version and latest_release %}
-            <div class="upgrade-section">
-                {% if current_version == latest_release.version %}
-                    <div>
-                        {% translate "All good. You are running on the latest version" %}!
-                    </div>
-                {% else %}
-                    {% if cms_upgrade_pending %}
-                        <div class="help-block help-warning">
-                            <svg class="icon icon-warning icon" aria-hidden="true">
-                                <use href="#icon-warning"></use>
-                            </svg>
-                            {% translate "A CMS upgrade was initiated. Please wait for the upgrade to complete" %}
-                        </div>
-                    {% else %}
-                        {% if cms_upgrade_hook_url %}
-                            <div class="upgrade-info">
-                                <span style="margin-right: 4px">
-                                    {% translate "CMS upgrade available" %}!
-                                </span>
-                                <a href="https://github.com/wmo-raf/nmhs-cms/releases" target="_blank"
-                                   rel="noopener noreferrer" style="text-decoration: underline">
-                                    {% translate "Release notes" %}
-                                </a>
-                            </div>
-                            <div style="margin-top: 20px">
-                                <form method="POST"
-                                      enctype="multipart/form-data">
-                                    {% if form.non_field_errors %}
-                                        <div class="non-field_errors" style="margin-bottom: 20px">
-                                            {% include "wagtailadmin/shared/non_field_errors.html" with form=form %}
-                                        </div>
-                                    {% endif %}
-                                    <ul class="fields">
-                                        {% csrf_token %}
-                                        {% for field in form %}
-                                            {% if field.is_hidden %}
-                                                {{ field }}
-                                            {% else %}
-                                                {% include "wagtailadmin/shared/field_as_li.html" %}
-                                            {% endif %}
-                                        {% endfor %}
-                                        <li>
-                                            <button class="button bicolor button--icon" type="submit">
-                                                <span class="icon-wrapper">
-                                                    <svg class="icon icon-rotate icon" aria-hidden="true">
-                                                        <use href="#icon-rotate"></use>
-                                                    </svg>
-                                                </span>
-                                                {% translate "Upgrade now" %}
-                                            </button>
-                                        </li>
-                                    </ul>
-                                </form>
-                            </div>
-                        {% endif %}
-                    {% endif %}
+        {% if error %}
+            <div class="help-block help-critical">
+                <svg class="icon icon-warning icon" aria-hidden="true">
+                    <use href="#icon-warning"></use>
+                </svg>
+                {{ error_message }}
+                {% if error_traceback %}
+                    <pre>{{ error_traceback }}</pre>
                 {% endif %}
             </div>
+        {% else %}
+            {% if current_version %}
+                <div class="v-item">
+                    {% translate "Current installed version" %}: <strong>{% cms_version %}</strong>
+                </div>
+            {% endif %}
+
+            {% if latest_release and has_new_version %}
+                <div class="v-item">
+                    {% translate "Latest available version" %}:
+                    <strong>{{ latest_release.version }}</strong></div>
+            {% endif %}
+
+            {% if current_version and latest_release %}
+                <div class="upgrade-section">
+                    {% if not has_new_version %}
+                        <div>
+                            {% translate "Your CMS version is up to date." %}
+                        </div>
+                    {% else %}
+                        {% if cms_upgrade_pending %}
+                            <div class="help-block help-warning">
+                                <svg class="icon icon-warning icon" aria-hidden="true">
+                                    <use href="#icon-warning"></use>
+                                </svg>
+                                {% translate "A CMS upgrade was initiated. Please wait for the upgrade to complete" %}
+                            </div>
+                        {% else %}
+                            {% if cms_upgrade_hook_url %}
+                                <div class="upgrade-info">
+                                    <span style="margin-right: 4px">
+                                        {% translate "CMS upgrade available" %}!
+                                    </span>
+                                    <a href="{{ latest_release.html_url }}" target="_blank"
+                                       rel="noopener noreferrer" style="text-decoration: underline">
+                                        {% translate "Release notes" %}
+                                    </a>
+                                </div>
+                                <div style="margin-top: 20px">
+                                    <form method="POST"
+                                          enctype="multipart/form-data">
+                                        {% if form.non_field_errors %}
+                                            <div class="non-field_errors" style="margin-bottom: 20px">
+                                                {% include "wagtailadmin/shared/non_field_errors.html" with form=form %}
+                                            </div>
+                                        {% endif %}
+                                        <ul class="fields">
+                                            {% csrf_token %}
+                                            {% for field in form %}
+                                                {% if field.is_hidden %}
+                                                    {{ field }}
+                                                {% else %}
+                                                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                                                {% endif %}
+                                            {% endfor %}
+                                            <li>
+                                                <button class="button bicolor button--icon" type="submit">
+                                                    <span class="icon-wrapper">
+                                                        <svg class="icon icon-rotate icon" aria-hidden="true">
+                                                            <use href="#icon-rotate"></use>
+                                                        </svg>
+                                                    </span>
+                                                    {% translate "Upgrade now" %}
+                                                </button>
+                                            </li>
+                                        </ul>
+                                    </form>
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    {% endif %}
+                </div>
+            {% endif %}
         {% endif %}
     </div>
 {% endblock %}

--- a/base/templatetags/nmhs_cms_tags.py
+++ b/base/templatetags/nmhs_cms_tags.py
@@ -2,6 +2,7 @@ import calendar
 import logging
 import os
 from datetime import datetime
+from html.parser import HTMLParser
 
 from django import template
 from django.conf import settings
@@ -9,13 +10,18 @@ from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import stringfilter, truncatewords_html
 from django.utils.safestring import mark_safe
 from wagtail.models import Site, Page
-from html.parser import HTMLParser
 
 from base.models import LanguageSettings
 from base.utils import get_first_non_empty_p_string
+from nmhs_cms import __version__
 
 logger = logging.getLogger(__name__)
 register = template.Library()
+
+
+@register.simple_tag
+def cms_version():
+    return __version__
 
 
 @register.filter
@@ -221,11 +227,9 @@ class ExcludeImagesParser(HTMLParser):
     def handle_starttag(self, tag, attrs):
         if tag.lower() == 'img':
             return
-        
+
         attr_repl = [f"{attr[0]}=\"{attr[1]}\"" for attr in attrs]
         self.result.append(f'<{tag} {" ".join(attr_repl)}>')
-
-        
 
     def handle_endtag(self, tag):
         if tag.lower() == 'img':
@@ -235,9 +239,11 @@ class ExcludeImagesParser(HTMLParser):
     def handle_data(self, data):
         self.result.append(data)
 
+
 def exclude_images(value):
     parser = ExcludeImagesParser()
     parser.feed(value)
     return ''.join(parser.result)
+
 
 register.filter('exclude_images', exclude_images)

--- a/nmhs_cms/__init__.py
+++ b/nmhs_cms/__init__.py
@@ -1,11 +1,9 @@
-from nmhs_cms.utils.version import get_version
-# from nmhs_cms.settings.base import CMS_VERSION
+from nmhs_cms.utils.version import get_version, get_semver_version
 
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-# VERSION = (CMS_VERSION.split('.')[0], CMS_VERSION.split('.')[1], CMS_VERSION.split('.')[2], "final", 0)
-
-# TODO: Dynamic versioning 
-VERSION = (0, 6, 9, "final" , 0) 
+VERSION = (0, 8, 89, "beta", 1)
 
 __version__ = get_version(VERSION)
+
+__semver__ = get_semver_version(VERSION)

--- a/nmhs_cms/settings/base.py
+++ b/nmhs_cms/settings/base.py
@@ -459,8 +459,6 @@ DJANGO_TABLES2_TEMPLATE = "django-tables2/bulma.html"
 
 ADMIN_URL_PATH = env.str("ADMIN_URL_PATH")
 
-CMS_VERSION = env.str("CMS_VERSION", default="")
-
 CMS_UPGRADE_HOOK_URL = env.str("CMS_UPGRADE_HOOK_URL", default="")
 
 # mqtt broker

--- a/nmhs_cms/templates/navigation/footer.html
+++ b/nmhs_cms/templates/navigation/footer.html
@@ -28,15 +28,15 @@
                         <p class="has-text-white footer-text">
                             &copy; {{ settings.base.OrganisationSetting.name }} {% now 'Y' %}</p>
                     {% endif %}
-                    {% if 'CMS_VERSION'|django_settings %}
-                        <a
-                                href="https://github.com/wmo-raf/nmhs-cms"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                style="color:#ababab; font-size: 12px;  font-weight:600">
-                            <span> {% translate "Powered by NMHS CMS" %} v{{ 'CMS_VERSION'|django_settings }}</span>
-                        </a>
-                    {% endif %}
+                    <a
+                            href="https://github.com/wmo-raf/nmhs-cms"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style="color:#ababab; font-size: 12px;  font-weight:600">
+                        <span>
+                            {% translate "Powered by Climweb" %} v{% cms_version %}
+                        </span>
+                    </a>
                 </div>
                 <div class="column is-half" style="display: flex;justify-content: flex-end;">
                     {% for account in settings.base.OrganisationSetting.social_media_accounts %}

--- a/nmhs_cms/templates/wagtailadmin/base.html
+++ b/nmhs_cms/templates/wagtailadmin/base.html
@@ -12,15 +12,11 @@
             <img src="{% static 'img/logo.svg' %}" alt="CMS Dashboard Logo"
                  style="height: 100%;width: 100%;object-fit: contain"/>
         {% endif %}
-
-        
     </figure>
-    
-    {% if 'CMS_VERSION'|django_settings %}
+
     <a href="{% url 'cms-version' %}" style="color:#ababab; font-size: 12px; padding-top:1em; font-weight:600">
-        <span> v{{ 'CMS_VERSION'|django_settings }}</span>
+        <span> v{% cms_version %}</span>
     </a>
-    {% endif %}
 
 {% endblock %}
 

--- a/nmhs_cms/utils/version.py
+++ b/nmhs_cms/utils/version.py
@@ -17,14 +17,16 @@ def get_version(version):
         mapping = {"alpha": "a", "beta": "b", "rc": "rc", "dev": ".dev"}
         sub = mapping[version[3]] + str(version[4])
 
-    return main
+    return main + sub
 
 
-def get_main_version(version=None):
+def get_main_version(version=None, include_patch=True):
     """Return main version (X.Y[.Z]) from VERSION."""
     version = get_complete_version(version)
-    parts = 2 if version[2] == 0 else 3
-
+    if include_patch:
+        parts = 2 if version[2] == 0 else 3
+    else:
+        parts = 2
     return ".".join(str(x) for x in version[:parts])
 
 
@@ -33,7 +35,6 @@ def get_complete_version(version=None):
     Return a tuple of the Wagtail version. If version argument is non-empty,
     check for correctness of the tuple provided.
     """
-
     if version is None:
         from nmhs_cms import VERSION as version
     else:
@@ -51,3 +52,59 @@ def get_semver_version(version):
     if version[3] != "final":
         sub = "-{}.{}".format(*version[3:])
     return main + sub
+
+
+def get_main_version_from_string(version_str):
+    """
+    Return the main version (X.Y[.Z]) from a version string.
+    """
+    version = version_str.split(".")
+    version_release = "final"
+
+    release_strings_to_check = ["dev", "alpha", "beta", "rc", "final"]
+    for release_string in release_strings_to_check:
+        if release_string in version_str:
+            parts = version_str.split(release_string)
+            version = parts[0].split(".")
+            version_release = release_string
+            break
+
+    if len(version) == 2:
+        return int(version[0]), int(version[1]), 0, version_release
+    return int(version[0]), int(version[1]), int(version[2]), version_release
+
+
+def check_version_greater_than_current(version):
+    """
+    Check if the given version is greater than the current version.
+    """
+    current_version = get_complete_version()
+    current_major, current_minor, current_patch, current_release = current_version[:4]
+
+    version = get_main_version_from_string(version)
+    major, minor, patch, release = version
+
+    # only check for final releases
+    if release != "final":
+        return False
+
+    # If the major version is greater than the current major version, return True
+    if major > current_major:
+        return True
+
+    # If the major version is the same, proceed to check the minor version
+    if major == current_major:
+        # If the minor version is greater than the current minor version, return True
+        if minor > current_minor:
+            return True
+
+        if minor == current_minor:
+
+            # If the major and minor versions are the same, check the patch version
+            if patch > current_patch:
+                return True
+
+            if patch == current_patch and current_release != "final":
+                return True
+
+    return False


### PR DESCRIPTION
Initially, the CMS_VERSION env variable used to indicate the current version. This was not efficient as failed updates could give a false update impression.

This PR brings the version updates to the cms code. This way we trully know if the code was updated.

Closes #148 