### PR TITLE
Catch form emailing errors for Contact Us, Feedback, Events and Data Request form pages

### DIFF
--- a/climweb/src/climweb/base/mail.py
+++ b/climweb/src/climweb/base/mail.py
@@ -28,8 +28,8 @@ def send_mail(subject, message, recipient_list, from_email=None, **kwargs):
         elif hasattr(settings, 'DEFAULT_FROM_EMAIL'):
             from_email = settings.DEFAULT_FROM_EMAIL
         else:
-            from_email = 'webmaster@localhost'
-
+            from_email = 'climweb@localhost'
+    
     connection = kwargs.get('connection', False) or get_connection(
         username=kwargs.get('auth_user', None),
         password=kwargs.get('auth_password', None),
@@ -41,13 +41,22 @@ def send_mail(subject, message, recipient_list, from_email=None, **kwargs):
             'Auto-Submitted': 'auto-generated',
         }
     }
-
+    
     if kwargs.get("reply_to", None):
         multi_alt_kwargs["reply_to"] = kwargs.get("reply_to")
-
+    
     mail = EmailMultiAlternatives(subject, message, from_email, recipient_list, **multi_alt_kwargs)
     html_message = kwargs.get('html_message', None)
     if html_message:
         mail.attach_alternative(html_message, 'text/html')
-
+    
     return mail.send()
+
+
+def get_default_from_email():
+    if hasattr(settings, 'WAGTAILADMIN_NOTIFICATION_FROM_EMAIL'):
+        return settings.WAGTAILADMIN_NOTIFICATION_FROM_EMAIL
+    elif hasattr(settings, 'DEFAULT_FROM_EMAIL'):
+        return settings.DEFAULT_FROM_EMAIL
+    else:
+        return 'climweb@localhost'

--- a/climweb/src/climweb/pages/contact/models.py
+++ b/climweb/src/climweb/pages/contact/models.py
@@ -5,6 +5,7 @@ from django.core.mail import mail_admins
 from django.template.response import TemplateResponse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+from loguru import logger
 from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import MultiFieldPanel, FieldRowPanel, FieldPanel, InlinePanel
 from wagtail.contrib.forms.models import AbstractEmailForm, AbstractFormField
@@ -88,7 +89,8 @@ class ContactPage(MetadataPageMixin, WagtailCaptchaEmailForm):
                 try:
                     # see if we have any duplicated field values. Notorious with spammers !
                     duplicate_fields = get_duplicates(form.cleaned_data)
-                except Exception:
+                except Exception as e:
+                    logger.warning("[CONTACT_US_PAGE] Error checking for duplicate fields: {}".format(e))
                     duplicate_fields = []
                 
                 if not duplicate_fields:
@@ -98,8 +100,8 @@ class ContactPage(MetadataPageMixin, WagtailCaptchaEmailForm):
                     # Send confirmation email
                     try:
                         self.send_confirmation_email(form.cleaned_data)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.error("[CONTACT_US_PAGE] Error sending confirmation email: {}".format(e))
                 else:
                     self.process_suspicious_form(form)
                 
@@ -132,30 +134,33 @@ class ContactPage(MetadataPageMixin, WagtailCaptchaEmailForm):
             self.send_suspicious_form_to_admin(form)
         except Exception as e:
             pass
-            
-            # override send_mail to extract sender email from form, to use in 'reply_to'
-            # This will allow replying to the sender directly from the email client
     
     def send_mail(self, form):
-        addresses = [x.strip() for x in self.to_address.split(',')]
-        email = form.cleaned_data.get("email", None)
-        options = {
-            "fail_silently": True,
-        }
-        if email:
-            options["reply_to"] = [email]
-        send_mail(self.subject, self.render_email(form), addresses, self.from_address, **options)
+        try:
+            addresses = [x.strip() for x in self.to_address.split(',')]
+            email = form.cleaned_data.get("email", None)
+            options = {
+                "fail_silently": True,
+            }
+            if email:
+                options["reply_to"] = [email]
+            send_mail(self.subject, self.render_email(form), addresses, self.from_address, **options)
+        except Exception as e:
+            logger.error("[CONTACT_US_PAGE] Error sending email: {}".format(e))
     
     def send_suspicious_form_to_admin(self, form):
-        content = []
-        for field in form:
-            value = field.value()
-            if isinstance(value, list):
-                value = ', '.join(value)
-            content.append('{}: {}'.format(field.label, value))
-        content = '\n'.join(content)
-        
-        mail_admins("POSSIBLE SPAM (CONTACT US PAGE) - {}".format(self.subject), content, fail_silently=True)
+        try:
+            content = []
+            for field in form:
+                value = field.value()
+                if isinstance(value, list):
+                    value = ', '.join(value)
+                content.append('{}: {}'.format(field.label, value))
+            content = '\n'.join(content)
+            
+            mail_admins("POSSIBLE SPAM (CONTACT US PAGE) - {}".format(self.subject), content, fail_silently=True)
+        except Exception as e:
+            logger.error("[CONTACT_US_PAGE] Suspicious form, Error sending email: {}".format(e))
     
     class Meta:
         verbose_name = _("Contact Page")

--- a/climweb/src/climweb/pages/events/models.py
+++ b/climweb/src/climweb/pages/events/models.py
@@ -39,6 +39,7 @@ from climweb.base.utils import (
     get_first_non_empty_p_string
 )
 from .blocks import PanelistBlock, EventSponsorBlock, SessionBlock
+from loguru import logger
 
 SUMMARY_RICHTEXT_FEATURES = getattr(settings, "SUMMARY_RICHTEXT_FEATURES")
 
@@ -654,8 +655,9 @@ class EventRegistrationPage(MetadataPageMixin, WagtailCaptchaEmailForm, Abstract
                                         "make sure the correct field is set to avoid duplicate submissions and "
                                         "stop these messages from being sent".format(self.validation_field, self.title),
                                 fail_silently=True)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.error("[EVENT_REGISTRATION_PAGE] Incorrect form validation field."
+                                 " Error sending email to admins: {}".format(e))
                 
                 # meanwhile, mark the form for saving
                 should_process = True


### PR DESCRIPTION
- Use `DEFAULT_FROM_EMAIL` when a Wagtail Form Builder Page's`from_address` is not set
- Use `try catch` to handle email sending errors that may occur. We don't want to stop the form submission. Rather we log errors for further investigation