### PR TITLE
Update wagtail-icon-chooser to 0.3.1, and packages using it

### DIFF
--- a/climweb/requirements/base.in
+++ b/climweb/requirements/base.in
@@ -1,4 +1,4 @@
-alertwise==1.0.4
+alertwise==1.0.5
 Cartopy==0.22.0
 celery==5.2.7
 celery-singleton==0.3.1
@@ -35,7 +35,7 @@ djangorestframework-xml==2.0.0
 Fiona
 fonttools==4.55.0
 forecastmanager==0.5.5
-geomanager==0.5.2
+geomanager==0.5.3
 google-api-python-client==2.79.0
 gunicorn==20.1.0
 lxml==5.3.0
@@ -56,7 +56,7 @@ wagtail-color-panel==1.4.1
 wagtail-django-recaptcha==1.0
 wagtail-font-awesome-svg==1.0.1
 wagtail-humanitarian-icons==2.0.0
-wagtail-icon-chooser==0.3.0
+wagtail-icon-chooser==0.3.1
 wagtail-lazyimages==0.1.5
 wagtail-mailchimp-integration==0.1.0
 wagtail-mautic-integration==0.0.1


### PR DESCRIPTION
- This PR updates wagtail-icon-chooser to 0.3.1, that fixes an issue with the IconChooserBlock that was prevent icon selection and closing the Icon chooser modal. Packages with wagtail-icon-chooser as a dependency have also been updated