### PR TITLE
Update packages showing WidgetWithScript deprecation warning

### DIFF
--- a/climweb/requirements/base.in
+++ b/climweb/requirements/base.in
@@ -52,7 +52,7 @@ wagtail==6.3.2
 wagtail-2fa==1.6.9
 wagtail-adminsortable @ https://github.com/wmo-raf/wagtail-admin-sortable/archive/33bf22f290e7a4210b44667e9ff56e4b35ad309e.zip
 wagtail-cache==2.5.1
-wagtail-color-panel==1.4.1
+wagtail-color-panel==1.6.0
 wagtail-django-recaptcha==1.0
 wagtail-font-awesome-svg==1.0.1
 wagtail-humanitarian-icons==2.0.0
@@ -66,7 +66,7 @@ wagtail-modelchooser==4.0.1
 wagtail-surveyjs==0.2.0
 wagtail-webstories-editor==0.2.0
 wagtail-zoom-integration==0.0.8
-wagtailgeowidget==7.0.0
+wagtailgeowidget==8.2.1
 wagtailleafletwidget==1.0.3
 weasyprint
 dj-database-url==2.3.0

--- a/climweb/requirements/base.txt
+++ b/climweb/requirements/base.txt
@@ -860,7 +860,7 @@ wagtail-cache==2.5.1
     #   -r base.in
     #   adm-boundary-manager
     #   geomanager
-wagtail-color-panel==1.4.1
+wagtail-color-panel==1.6.0
     # via
     #   -r base.in
     #   geomanager
@@ -912,7 +912,7 @@ wagtail-webstories-editor==0.2.0
     # via -r base.in
 wagtail-zoom-integration==0.0.8
     # via -r base.in
-wagtailgeowidget==7.0.0
+wagtailgeowidget==8.2.1
     # via
     #   -r base.in
     #   forecastmanager


### PR DESCRIPTION
Update wagtailgeowidget and wagtail-color-panel to latest versions supporting Wagtail>6.x to remove WidgetWithScript deprecation warning