### PR TITLE
Update wagtail-2fa to use repo

### DIFF
--- a/climweb/requirements/base.in
+++ b/climweb/requirements/base.in
@@ -49,7 +49,7 @@ psycopg2>=2.9.10
 python-dateutil==2.9.0.post0
 uvicorn[standard]==0.30.5
 wagtail==7.0
-wagtail-2fa==1.6.9
+wagtail-2fa @ https://github.com/wmo-raf/wagtail-2fa/archive/80163a0f7db800ae654ae9fbff2a401f3535b4c3.zip
 wagtail-adminsortable @ https://github.com/wmo-raf/wagtail-admin-sortable/archive/33bf22f290e7a4210b44667e9ff56e4b35ad309e.zip
 wagtail-cache @ https://github.com/coderedcorp/wagtail-cache/archive/c7c2396e59935978338f42de37a0dfc9b8f73786.zip
 wagtail-color-panel==1.6.0

--- a/climweb/requirements/base.txt
+++ b/climweb/requirements/base.txt
@@ -848,7 +848,7 @@ wagtail==7.0
     #   wagtail-zoom-integration
     #   wagtailgeowidget
     #   wagtailmedia
-wagtail-2fa==1.6.9
+wagtail-2fa @ https://github.com/wmo-raf/wagtail-2fa/archive/80163a0f7db800ae654ae9fbff2a401f3535b4c3.zip
     # via -r base.in
 wagtail-adminsortable @ https://github.com/wmo-raf/wagtail-admin-sortable/archive/33bf22f290e7a4210b44667e9ff56e4b35ad309e.zip
     # via -r base.in


### PR DESCRIPTION
- The upstream wagtail-2fa has not been updated for sometime. For now we use a fork that fixes support for Wagtail 7.0