### PR TITLE
Update default database settings

### DIFF
--- a/climweb/src/climweb/config/settings/base.py
+++ b/climweb/src/climweb/config/settings/base.py
@@ -265,14 +265,15 @@ ASGI_APPLICATION = "climweb.config.asgi.application"
 DB_ENGINE = "climweb.config.db_engine"
 
 DB_CONNECTION_MAX_AGE = env.int("DB_CONNECTION_MAX_AGE", default=0)
-DB_DISABLE_SERVER_SIDE_CURSORS = env.bool("DB_DISABLE_SERVER_SIDE_CURSORS", default=True)
+DB_CONN_HEALTH_CHECKS = env.bool("DB_CONN_HEALTH_CHECKS", default=False)
+DB_DISABLE_SERVER_SIDE_CURSORS = env.bool("DB_DISABLE_SERVER_SIDE_CURSORS", default=False)
 DB_SSL_REQUIRE = env.bool("DB_SSL_REQUIRE", default=False)
 
 DATABASES = {
     "default": dj_database_url.config(
         engine=DB_ENGINE,
         conn_max_age=DB_CONNECTION_MAX_AGE,
-        conn_health_checks=True,
+        conn_health_checks=DB_CONN_HEALTH_CHECKS,
         disable_server_side_cursors=DB_DISABLE_SERVER_SIDE_CURSORS,
         ssl_require=DB_SSL_REQUIRE,
     )


### PR DESCRIPTION
- This PR sets the default values for DB settings that can be overridden with env variables. This allows to change the settings when using PgBouncer for connection pooling

```
DB_CONNECTION_MAX_AGE = env.int("DB_CONNECTION_MAX_AGE", default=0)
DB_CONN_HEALTH_CHECKS = env.bool("DB_CONN_HEALTH_CHECKS", default=False)
DB_DISABLE_SERVER_SIDE_CURSORS = env.bool("DB_DISABLE_SERVER_SIDE_CURSORS", default=False)
DB_SSL_REQUIRE = env.bool("DB_SSL_REQUIRE", default=False)
```