### PR TITLE
Fix getting correcly formatted summary text for featured news and events

### DIFF
--- a/climweb/src/climweb/config/templates/featured_item_include.html
+++ b/climweb/src/climweb/config/templates/featured_item_include.html
@@ -35,7 +35,7 @@
                 </a>
             </h3>
             <div class="featured-item-snippet format-text">
-                {{ item_text|richtext|html_summary:100 }}
+                {{ item_text }}
             </div>
         </div>
         <div class="featured-item-meta">

--- a/climweb/src/climweb/pages/events/templates/event_index_page.html
+++ b/climweb/src/climweb/pages/events/templates/event_index_page.html
@@ -16,7 +16,7 @@
                     <h2 class="section-title center">
                         {% translate "Featured Event" %}
                     </h2>
-                    {% include 'featured_item_include.html' with item_image=featured_event.image item_title=featured_event.title item_text=featured_event.description item_url=featured_event.url item_meta=featured_event.date_from %}
+                    {% include 'featured_item_include.html' with item_image=featured_event.image item_title=featured_event.title item_text=featured_event.listing_summary item_url=featured_event.url item_meta=featured_event.date_from %}
                 </div>
             </section>
         {% endif %}

--- a/climweb/src/climweb/pages/news/templates/news_index_page.html
+++ b/climweb/src/climweb/pages/news/templates/news_index_page.html
@@ -16,7 +16,7 @@
                     <h2 class="section-title center">
                         {% translate "Featured News" %}
                     </h2>
-                    {% include 'featured_item_include.html' with item_image_src=featured_news.card_props.card_image item_title=featured_news.title item_text=featured_news.body item_url=featured_news.url item_meta=featured_news.date item_tags=featured_news.tags %}
+                    {% include 'featured_item_include.html' with item_image_src=featured_news.card_props.card_image item_title=featured_news.title item_text=featured_news.listing_summary item_url=featured_news.url item_meta=featured_news.date item_tags=featured_news.tags %}
                 </div>
             </section>
         {% endif %}

--- a/climweb/src/climweb/version.py
+++ b/climweb/src/climweb/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (1, 0, 5, "final", 0)
+VERSION = (1, 0, 6, "beta", 1)
 
 def get_semver_version(version):
     "Returns the semver version (X.Y.Z[-(alpha|beta)]) from VERSION"


### PR DESCRIPTION
This PR fixes an issue where the summary text for featured news and event items was not correctly formatted, especially for French