### PR TITLE
Address merge conflict in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,7 @@
 :hidetoc: 1
 
-<<<<<<< HEAD
 Welcome to NMHS ClimWeb documentation
 =======================================
-=======
-Welcome to ClimWeb documentation
-==================================
->>>>>>> dd740772b2aaaee1d403d28429c010791b628116
 
 .. image:: _static/images/home/cms_responsive.png
 
@@ -19,13 +14,8 @@ Downloadable pdf versions can be found at:
    * :download:`ClimWeb Manual (Swahili) <https://climweb.readthedocs.io/_/downloads/sw/latest/pdf/>`
 
 
-<<<<<<< HEAD
 NMHS ClimWeb
 -------------
-=======
-ClimWeb
----------
->>>>>>> dd740772b2aaaee1d403d28429c010791b628116
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 :hidetoc: 1
 
-Welcome to NMHS ClimWeb documentation
-=======================================
+Welcome to ClimWeb documentation
+==================================
 
 .. image:: _static/images/home/cms_responsive.png
 
@@ -14,8 +14,8 @@ Downloadable pdf versions can be found at:
    * :download:`ClimWeb Manual (Swahili) <https://climweb.readthedocs.io/_/downloads/sw/latest/pdf/>`
 
 
-NMHS ClimWeb
--------------
+ClimWeb
+---------
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Hi, I noticed a merge conflict sneaked in while browsing the ClimWeb documentation at https://climweb.readthedocs.io/en/latest/

This patch will pick the NMHS ClimWeb phrasing.

<img width="2848" height="1704" alt="image" src="https://github.com/user-attachments/assets/325b9142-3363-44a0-8311-c2d95666cbf4" />
