### PR TITLE
Disable scheduled translation sync job

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -1,8 +1,8 @@
 name: Sync translations from Crowdin (production)
 
 on:
-  schedule:
-    - cron: "0 */3 * * *"  # every 3 hours
+  # schedule:
+  #   - cron: "0 */3 * * *"  # every 3 hours
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Comment out the scheduled cron job for syncing translations.