### PR TITLE
Add .gitignore entries for sensitive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,10 @@ backup/
 .vscode/
 node_modules/
 tmp/
+# Private keys and credentials
+*.pem
+*.key
+*.p12
+*.pfx
+credentials.json
+service-account*.json

--- a/.gitignore
+++ b/.gitignore
@@ -187,10 +187,3 @@ backup/
 .vscode/
 node_modules/
 tmp/
-# Private keys and credentials
-*.pem
-*.key
-*.p12
-*.pfx
-credentials.json
-service-account*.json


### PR DESCRIPTION
The .gitignore is missing entries for private keys and credentials (`*.pem`, `*.key`, `*.p12`, `*.pfx`, `credentials.json`, `service-account*.json`). Added those to help prevent accidental commits of sensitive files.