### PR TITLE
Fix incorrect Dockerfile path name

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,7 +11,7 @@ services:
     restart: no
     build:
       context: .
-      dockerfile: ./climweb/Dockerfile
+      dockerfile: Dockerfile
       target: dev
       args:
         - UID=${UID}


### PR DESCRIPTION
This updates the climweb_dev build config in docker-compose.dev.yml to use the correct Dockerfile path; tested on a linux machine.