### PR TITLE
Add "Create CAP alert from geometry" route

### DIFF
--- a/climweb/src/climweb/base/cap.py
+++ b/climweb/src/climweb/base/cap.py
@@ -1,3 +1,5 @@
+import json
+
 from django.utils.translation import gettext as _
 
 from climweb.base.models import ImportantPages
@@ -241,5 +243,75 @@ def get_cap_map_style(geojson):
             del layer["filter"]
     
     style["layers"].extend(layers)
-    
+
     return style
+
+
+def extract_polygon_geometry(geojson):
+    """
+    Return the first Polygon/MultiPolygon geometry found in a GeoJSON geometry,
+    Feature or FeatureCollection, or None if none is found.
+    """
+    if not isinstance(geojson, dict):
+        return None
+
+    geojson_type = geojson.get("type")
+
+    if geojson_type == "FeatureCollection":
+        for feature in geojson.get("features") or []:
+            geometry = extract_polygon_geometry(feature)
+            if geometry is not None:
+                return geometry
+        return None
+
+    if geojson_type == "Feature":
+        return extract_polygon_geometry(geojson.get("geometry"))
+
+    if geojson_type in ("Polygon", "MultiPolygon"):
+        return geojson
+
+    return None
+
+
+def build_area_info_blocks(request):
+    """
+    Build the ``info`` StreamField raw value with a single Alert Information block
+    whose area is pre-filled from the ``geometry`` parameter, or None if no valid
+    Polygon/MultiPolygon geometry is provided.
+
+    The geometry is read from POST (the MapViewer submits it as a form body to
+    avoid GET URL length limits) with a GET fallback for manual testing.
+    """
+    data = request.POST if request.method == "POST" else request.GET
+
+    geometry_param = data.get("geometry")
+    if not geometry_param:
+        return None
+
+    try:
+        geojson = json.loads(geometry_param)
+    except (ValueError, TypeError):
+        return None
+
+    geometry = extract_polygon_geometry(geojson)
+    if geometry is None:
+        return None
+
+    area_desc = (data.get("areaDesc") or "").strip()
+
+    return [
+        {
+            "type": "alert_info",
+            "value": {
+                "area": [
+                    {
+                        "type": "polygon_block",
+                        "value": {
+                            "areaDesc": area_desc,
+                            "polygon": json.dumps(geometry),
+                        },
+                    }
+                ],
+            },
+        }
+    ]

--- a/climweb/src/climweb/base/cap_views.py
+++ b/climweb/src/climweb/base/cap_views.py
@@ -1,0 +1,74 @@
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseBadRequest
+from django.utils.translation import gettext as _
+from django.views.decorators.csrf import csrf_exempt
+from wagtail.admin.views.pages.create import CreateView
+from wagtail.blocks import StreamValue
+
+from .cap import build_area_info_blocks
+
+
+class CreateAlertFromGeometryView(CreateView):
+    """
+    Wagtail page CreateView that opens the standard 'add CAP alert' editor with the
+    Alert Information area pre-filled from a GeoJSON geometry.
+
+    The MapViewer submits the geometry via POST (a hidden form targeting a new
+    tab) to avoid GET URL length limits; a GET fallback is kept for manual
+    testing. In both cases nothing is written to the database — POST here only
+    re-renders the prefilled add form, it does NOT run the CreateView create
+    logic. Saving/publishing happens through the normal Wagtail add page flow
+    (the rendered form posts to ``wagtailadmin_pages:add`` with its own CSRF
+    token), so all validation and the usual field prefills apply as normal.
+    """
+
+    def _prefilled_form_response(self, request):
+        info_blocks = build_area_info_blocks(request)
+        if info_blocks:
+            self.page.info = StreamValue(
+                self.page.info.stream_block, info_blocks, is_lazy=True
+            )
+        return super().get(request)
+
+    def get(self, request):
+        return self._prefilled_form_response(request)
+
+    def post(self, request):
+        # Render the prefilled form; deliberately NOT super().post() (no create).
+        return self._prefilled_form_response(request)
+
+
+@csrf_exempt
+@login_required
+def create_alert_from_geometry(request):
+    """
+    Entry point used by the MapViewer 'Create CAP alert' button. Resolves the CAP
+    alert list page and renders the pre-filled add form via
+    :class:`CreateAlertFromGeometryView`. Permissions are enforced by the underlying
+    Wagtail CreateView (``can_add_subpage``).
+
+    The geometry is submitted as the ``geometry`` form field (POST body, URL-encoded
+    GeoJSON) so large polygons don't hit GET URL length limits; a GET ``geometry``
+    query param is still accepted for manual testing. A bare geometry, a Feature or a
+    FeatureCollection is accepted. An optional ``areaDesc`` field is used as the area
+    description.
+
+    ``csrf_exempt`` is safe here: this view only renders the prefilled add form and
+    writes nothing to the database (``@login_required`` still applies), while the
+    actual page creation posts to the CSRF-protected ``wagtailadmin_pages:add``.
+    """
+    from capcomposer.cap.models import CapAlertListPage
+
+    cap_list_page = CapAlertListPage.objects.live().first()
+
+    if not cap_list_page:
+        return HttpResponseBadRequest(
+            _("No CAP alert list page found. Please create one before adding alerts.")
+        )
+
+    return CreateAlertFromGeometryView.as_view()(
+        request,
+        content_type_app_name="cap",
+        content_type_model_name="capalertpage",
+        parent_page_id=cap_list_page.id,
+    )

--- a/climweb/src/climweb/base/templatetags/nmhs_cms_tags.py
+++ b/climweb/src/climweb/base/templatetags/nmhs_cms_tags.py
@@ -278,7 +278,7 @@ def render_charts(context, charts_block, section_index=0):
                  "index": i + 1,         
                  "section_index": section_index,
                 },
-                request=context["request"]
+                request=context.get("request")
             )
             rendered_output += rendered
             i += 2
@@ -288,7 +288,7 @@ def render_charts(context, charts_block, section_index=0):
                 {"chart": current, "index": i + 1,
                 "section_index": section_index,
                 },
-                request=context["request"]
+                request=context.get("request")
             )
             rendered_output += rendered
             i += 1
@@ -315,7 +315,7 @@ def render_chart_or_map(context, block, block_type="map", section_index=0, block
                  "section_index": section_index,
                  "block_index":block_index
                 },
-                request=context["request"]
+                request=context.get("request")
             )
             rendered_output += rendered
             i += 2
@@ -327,7 +327,7 @@ def render_chart_or_map(context, block, block_type="map", section_index=0, block
                 "section_index": section_index,
                 "block_index": block_index
                 },
-                request=context["request"]
+                request=context.get("request")
             )
             rendered_output += rendered
             i += 1

--- a/climweb/src/climweb/base/views.py
+++ b/climweb/src/climweb/base/views.py
@@ -2,15 +2,11 @@ import json
 import os
 
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
-from django.http import JsonResponse, HttpResponseBadRequest
+from django.http import JsonResponse
 from django.shortcuts import render, redirect
 from django.utils.translation import gettext as _
-from django.views.decorators.csrf import csrf_exempt
 from wagtail.admin import messages
-from wagtail.admin.views.pages.create import CreateView
-from wagtail.blocks import StreamValue
 
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -18,7 +14,6 @@ from climweb import __version__
 from climweb.base.utils import get_latest_cms_release, send_upgrade_command, send_plugin_remove, get_installed_plugins, \
     mix_with_white
 from climweb.utils.version import check_version_greater_than_current, get_main_version
-from .cap import build_area_info_blocks
 from .forms import CMSUpgradeForm
 from .models import Theme, OrganisationSetting
 
@@ -239,69 +234,3 @@ def cms_upgrade_status_view(request):
     status_data["cms_upgrade_pending"] = cache.get("cms_upgrade_pending", False)
 
     return JsonResponse(status_data)
-
-
-class CreateAlertFromGeometryView(CreateView):
-    """
-    Wagtail page CreateView that opens the standard 'add CAP alert' editor with the
-    Alert Information area pre-filled from a GeoJSON geometry.
-
-    The MapViewer submits the geometry via POST (a hidden form targeting a new
-    tab) to avoid GET URL length limits; a GET fallback is kept for manual
-    testing. In both cases nothing is written to the database — POST here only
-    re-renders the prefilled add form, it does NOT run the CreateView create
-    logic. Saving/publishing happens through the normal Wagtail add page flow
-    (the rendered form posts to ``wagtailadmin_pages:add`` with its own CSRF
-    token), so all validation and the usual field prefills apply as normal.
-    """
-
-    def _prefilled_form_response(self, request):
-        info_blocks = build_area_info_blocks(request)
-        if info_blocks:
-            self.page.info = StreamValue(
-                self.page.info.stream_block, info_blocks, is_lazy=True
-            )
-        return super().get(request)
-
-    def get(self, request):
-        return self._prefilled_form_response(request)
-
-    def post(self, request):
-        # Render the prefilled form; deliberately NOT super().post() (no create).
-        return self._prefilled_form_response(request)
-
-
-@csrf_exempt
-@login_required
-def create_alert_from_geometry(request):
-    """
-    Entry point used by the MapViewer 'Create CAP alert' button. Resolves the CAP
-    alert list page and renders the pre-filled add form via
-    :class:`CreateAlertFromGeometryView`. Permissions are enforced by the underlying
-    Wagtail CreateView (``can_add_subpage``).
-
-    The geometry is submitted as the ``geometry`` form field (POST body, URL-encoded
-    GeoJSON) so large polygons don't hit GET URL length limits; a GET ``geometry``
-    query param is still accepted for manual testing. A bare geometry, a Feature or a
-    FeatureCollection is accepted. An optional ``areaDesc`` field is used as the area
-    description.
-
-    ``csrf_exempt`` is safe here: this view only renders the prefilled add form and
-    writes nothing to the database (``@login_required`` still applies), while the
-    actual page creation posts to the CSRF-protected ``wagtailadmin_pages:add``.
-    """
-    from capcomposer.cap.models import CapAlertListPage
-
-    cap_list_page = CapAlertListPage.objects.live().first()
-
-    if not cap_list_page:
-        return HttpResponseBadRequest(
-            _("No CAP alert list page found. Please create one before adding alerts.")
-        )
-
-    return CreateAlertFromGeometryView.as_view()(
-        request,
-        content_type_app_name="cap",
-        content_type_model_name="capalertpage",
-        parent_page_id=cap_list_page.id,
-    )

--- a/climweb/src/climweb/base/views.py
+++ b/climweb/src/climweb/base/views.py
@@ -2,11 +2,15 @@ import json
 import os
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponseBadRequest
 from django.shortcuts import render, redirect
 from django.utils.translation import gettext as _
+from django.views.decorators.csrf import csrf_exempt
 from wagtail.admin import messages
+from wagtail.admin.views.pages.create import CreateView
+from wagtail.blocks import StreamValue
 
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -14,6 +18,7 @@ from climweb import __version__
 from climweb.base.utils import get_latest_cms_release, send_upgrade_command, send_plugin_remove, get_installed_plugins, \
     mix_with_white
 from climweb.utils.version import check_version_greater_than_current, get_main_version
+from .cap import build_area_info_blocks
 from .forms import CMSUpgradeForm
 from .models import Theme, OrganisationSetting
 
@@ -232,5 +237,71 @@ def cms_upgrade_status_view(request):
         cache.set("cms_upgrade_pending", False)
     
     status_data["cms_upgrade_pending"] = cache.get("cms_upgrade_pending", False)
-    
+
     return JsonResponse(status_data)
+
+
+class CreateAlertFromGeometryView(CreateView):
+    """
+    Wagtail page CreateView that opens the standard 'add CAP alert' editor with the
+    Alert Information area pre-filled from a GeoJSON geometry.
+
+    The MapViewer submits the geometry via POST (a hidden form targeting a new
+    tab) to avoid GET URL length limits; a GET fallback is kept for manual
+    testing. In both cases nothing is written to the database — POST here only
+    re-renders the prefilled add form, it does NOT run the CreateView create
+    logic. Saving/publishing happens through the normal Wagtail add page flow
+    (the rendered form posts to ``wagtailadmin_pages:add`` with its own CSRF
+    token), so all validation and the usual field prefills apply as normal.
+    """
+
+    def _prefilled_form_response(self, request):
+        info_blocks = build_area_info_blocks(request)
+        if info_blocks:
+            self.page.info = StreamValue(
+                self.page.info.stream_block, info_blocks, is_lazy=True
+            )
+        return super().get(request)
+
+    def get(self, request):
+        return self._prefilled_form_response(request)
+
+    def post(self, request):
+        # Render the prefilled form; deliberately NOT super().post() (no create).
+        return self._prefilled_form_response(request)
+
+
+@csrf_exempt
+@login_required
+def create_alert_from_geometry(request):
+    """
+    Entry point used by the MapViewer 'Create CAP alert' button. Resolves the CAP
+    alert list page and renders the pre-filled add form via
+    :class:`CreateAlertFromGeometryView`. Permissions are enforced by the underlying
+    Wagtail CreateView (``can_add_subpage``).
+
+    The geometry is submitted as the ``geometry`` form field (POST body, URL-encoded
+    GeoJSON) so large polygons don't hit GET URL length limits; a GET ``geometry``
+    query param is still accepted for manual testing. A bare geometry, a Feature or a
+    FeatureCollection is accepted. An optional ``areaDesc`` field is used as the area
+    description.
+
+    ``csrf_exempt`` is safe here: this view only renders the prefilled add form and
+    writes nothing to the database (``@login_required`` still applies), while the
+    actual page creation posts to the CSRF-protected ``wagtailadmin_pages:add``.
+    """
+    from capcomposer.cap.models import CapAlertListPage
+
+    cap_list_page = CapAlertListPage.objects.live().first()
+
+    if not cap_list_page:
+        return HttpResponseBadRequest(
+            _("No CAP alert list page found. Please create one before adding alerts.")
+        )
+
+    return CreateAlertFromGeometryView.as_view()(
+        request,
+        content_type_app_name="cap",
+        content_type_model_name="capalertpage",
+        parent_page_id=cap_list_page.id,
+    )

--- a/climweb/src/climweb/base/wagtail_hooks.py
+++ b/climweb/src/climweb/base/wagtail_hooks.py
@@ -27,7 +27,8 @@ from climweb.utils.version import get_main_version, check_version_greater_than_c
 from .cap import create_cap_geomanager_dataset
 from .models import Theme, ServiceCategory, CAPGeomanagerSettings
 from .utils import get_latest_cms_release
-from .views import cms_version_view, plugin_manager_view, cms_upgrade_status_view, create_alert_from_geometry
+from .views import cms_version_view, plugin_manager_view, cms_upgrade_status_view
+from .cap_views import create_alert_from_geometry
 
 
 class ModelAdminGroupWithHiddenItems(ModelAdminGroup):

--- a/climweb/src/climweb/base/wagtail_hooks.py
+++ b/climweb/src/climweb/base/wagtail_hooks.py
@@ -27,7 +27,7 @@ from climweb.utils.version import get_main_version, check_version_greater_than_c
 from .cap import create_cap_geomanager_dataset
 from .models import Theme, ServiceCategory, CAPGeomanagerSettings
 from .utils import get_latest_cms_release
-from .views import cms_version_view, plugin_manager_view, cms_upgrade_status_view
+from .views import cms_version_view, plugin_manager_view, cms_upgrade_status_view, create_alert_from_geometry
 
 
 class ModelAdminGroupWithHiddenItems(ModelAdminGroup):
@@ -48,11 +48,19 @@ def global_admin_css():
 
 @hooks.register('register_admin_urls')
 def urlconf_base():
-    return [
+    urls = [
         path('cms-version', cms_version_view, name='cms-version'),
         path('cms-upgrade-status', cms_upgrade_status_view, name='cms-upgrade-status'),
         path('plugins', plugin_manager_view, name='plugin-manager'),
     ]
+
+    if "capcomposer.cap" in settings.INSTALLED_APPS:
+        urls.append(
+            path('cap/create-from-geometry/', create_alert_from_geometry,
+                 name='cap_alert_create_from_geometry'),
+        )
+
+    return urls
 
 
 @hooks.register('register_settings_menu_item')


### PR DESCRIPTION
## Add "Create CAP alert from geometry" route

  Adds a climweb-specific admin route that opens the standard Wagtail "add CAP
  alert" editor with the alert area **pre-filled from a GeoJSON geometry**. It is
  meant to be triggered from the MapViewer: the user draws a geometry on the map
  and lands directly on the CAP alert form with that area already set.

  This is deliberately kept in climweb (not in `cap-composer`) since it is a
  climweb-specific use case.

  ### How it works

  - New route `cap/create-from-geometry/` (name `cap_alert_create_from_geometry`)
    registered via `register_admin_urls`, gated behind `capcomposer.cap` being
    installed.
  - `CreateAlertFromGeometryView` subclasses Wagtail's page `CreateView` and only
    **renders** the pre-filled add form — it writes nothing to the database. The
    actual create/publish happens through the normal Wagtail add-page flow, so all
    validation and standard field prefills apply as usual.
  - The geometry is read from the `geometry` field (POST body, URL-encoded GeoJSON)
    to avoid GET URL length limits on large polygons; a GET `geometry` query param
    is kept for manual testing. A bare geometry, a `Feature` or a
    `FeatureCollection` are all accepted, and an optional `areaDesc` field sets the
    area description.
  - `@login_required` is enforced, and page-add permissions are enforced by the
    underlying Wagtail `CreateView`. `@csrf_exempt` is safe here because the view
    only renders the prefilled form; the real creation posts to the
    CSRF-protected `wagtailadmin_pages:add`.
  - CAP data-building helpers (`extract_polygon_geometry`, `build_area_info_blocks`)
    live in `base/cap.py` next to the other CAP helpers; the HTTP views stay in
    `base/views.py`.
