### PR TITLE
feat(homepage): Auto-select featured city on homepage forecast

### DIFF
--- a/climweb/src/climweb/pages/home/models.py
+++ b/climweb/src/climweb/pages/home/models.py
@@ -277,6 +277,7 @@ class HomePage(MetadataPageMixin, Page):
 
         if "forecastmanager" in settings.INSTALLED_APPS:
             context["home_weather_widget_url"] = get_full_url(request, reverse("home-weather-widget"))
+            context["weather_city_locations_url"] = get_full_url(request, reverse("weather-city-locations"))
 
             if self.show_city_forecast:
                 from climweb.pages.weather.utils import get_city_forecast_detail_data

--- a/climweb/src/climweb/pages/home/models.py
+++ b/climweb/src/climweb/pages/home/models.py
@@ -268,7 +268,6 @@ class HomePage(MetadataPageMixin, Page):
             city_search_url = get_full_url(request, reverse("cities-list"))
             context.update({
                 "city_search_url": city_search_url,
-                "city_locations_url": city_search_url,
             })
         
         map_settings_url = get_full_url(request, reverse("home-map-settings"))

--- a/climweb/src/climweb/pages/home/models.py
+++ b/climweb/src/climweb/pages/home/models.py
@@ -268,6 +268,7 @@ class HomePage(MetadataPageMixin, Page):
             city_search_url = get_full_url(request, reverse("cities-list"))
             context.update({
                 "city_search_url": city_search_url,
+                "city_locations_url": city_search_url,
             })
         
         map_settings_url = get_full_url(request, reverse("home-map-settings"))
@@ -277,7 +278,6 @@ class HomePage(MetadataPageMixin, Page):
 
         if "forecastmanager" in settings.INSTALLED_APPS:
             context["home_weather_widget_url"] = get_full_url(request, reverse("home-weather-widget"))
-            context["weather_city_locations_url"] = get_full_url(request, reverse("weather-city-locations"))
 
             if self.show_city_forecast:
                 from climweb.pages.weather.utils import get_city_forecast_detail_data

--- a/climweb/src/climweb/pages/home/templates/home/home_page.html
+++ b/climweb/src/climweb/pages/home/templates/home/home_page.html
@@ -145,7 +145,7 @@
     const weatherWidgetWrapper = $("#weather-widget-wrapper");
 
     let singleForecastSlider;
-    let cityLocations;
+    let cityLocations = null;
 
     /* ── city select callback — triggers a full widget re-render ── */
     const onSelectCity = ({ label, value }) => {
@@ -377,29 +377,32 @@
       const d = R * c;
       return d; // distance in km
     }
+  
 
     /* Async function to fetch city locations from the backend, returns a promise that resolves to an array of city locations */
-    const fetchCityLocations = () => {
+    const fetchCityLocations = async () => {
       if (!weatherCityLocationsUrl) {
-        return Promise.resolve([]);
+        return [];
+      }
+
+      if (cityLocations) {
+        return cityLocations;
       }
 
       if (!cityLocations) {
-        fetch(weatherCityLocationsUrl)
-          .then(response => {
-            if (!response.ok) throw new Error('Error fetching city locations');
-            return response.json();
-          })
-          .then(data => {
-            cityLocations = Array.isArray(data.cities) ? data.cities : [];
-          })
-          .catch(error => {
-            console.error('CITY_LOCATIONS_ERROR:', error);
-            return [];
-          });
+        try {
+          const response = await fetch(weatherCityLocationsUrl);
+          if (!response.ok) throw new Error('Error fetching city locations');
+          
+          const data = await response.json();
+          cityLocations = Array.isArray(data.cities) ? data.cities : [];
+        } catch (error) {
+          console.error('CITY_LOCATIONS_ERROR:', error);
+          return [];
+        }
       }
       return cityLocations || [];
-    }
+    };
 
     /*  Async function to find nearest city to user  */
     let nearestCity = null;
@@ -414,15 +417,18 @@
         let minDistance = Infinity;
 
         cities.forEach(city => {
-          const distance = haversineDistanceKM(lat, lng, city.x, city.y);
+          const distance = haversineDistanceKM(lat, lng, city.lat, city.lng);
           if (distance < minDistance) {
             minDistance = distance;
             nearestCity = city;
           }
         });
-
         console.log(`Nearest city to user: ${nearestCity ? nearestCity.name : 'None found'}`);
+
+        renderWeatherWidgetForCity(nearestCity.slug)
         return nearestCity;
+
+        
       });
     };
 

--- a/climweb/src/climweb/pages/home/templates/home/home_page.html
+++ b/climweb/src/climweb/pages/home/templates/home/home_page.html
@@ -133,6 +133,7 @@
     <script>
     const homeMapSettingsUrl    = "{{ home_map_settings_url|default_if_none:'' }}";
     const homeWeatherWidgetUrl  = "{{ home_weather_widget_url|default_if_none:'' }}";
+    const weatherCityLocationsUrl = "{{ weather_city_locations_url|default_if_none:'' }}";
     const page_youtube_playlist = {{ page.youtube_playlist|yesno:'true,false' }};
     const citySearchUrl         = "{{ city_search_url }}";
     const cityDetailUrl         = "{{ city_detail_page_url|default_if_none:'' }}";
@@ -144,6 +145,7 @@
     const weatherWidgetWrapper = $("#weather-widget-wrapper");
 
     let singleForecastSlider;
+    let cityLocations;
 
     /* ── city select callback — triggers a full widget re-render ── */
     const onSelectCity = ({ label, value }) => {
@@ -351,9 +353,104 @@
         });
     };
 
+    /*  ── GEOLOCATION FOR NEAREST CITY TO USER  ── */
+    /* Function to calculate the distance between two points on Earth, using the Haversine formula */
+    function haversineDistanceKM(lat1Deg, lng1Deg, lat2Deg, lng2Deg) {
+      function toRad(degree) {
+          return degree * Math.PI / 180;
+      }
+      
+      const lat1 = toRad(lat1Deg);
+      const lng1 = toRad(lng1Deg);
+      const lat2 = toRad(lat2Deg);
+      const lng2 = toRad(lng2Deg);
+      
+      const { sin, cos, sqrt, atan2 } = Math;
+      
+      const R = 6371; // earth radius in km 
+      const dLat = lat2 - lat1;
+      const dLon = lng2 - lng1;
+      const a = sin(dLat / 2) * sin(dLat / 2)
+              + cos(lat1) * cos(lat2)
+              * sin(dLon / 2) * sin(dLon / 2);
+      const c = 2 * atan2(sqrt(a), sqrt(1 - a)); 
+      const d = R * c;
+      return d; // distance in km
+    }
+
+    /* Async function to fetch city locations from the backend, returns a promise that resolves to an array of city locations */
+    const fetchCityLocations = () => {
+      if (!weatherCityLocationsUrl) {
+        return Promise.resolve([]);
+      }
+
+      if (!cityLocations) {
+        fetch(weatherCityLocationsUrl)
+          .then(response => {
+            if (!response.ok) throw new Error('Error fetching city locations');
+            return response.json();
+          })
+          .then(data => {
+            cityLocations = Array.isArray(data.cities) ? data.cities : [];
+          })
+          .catch(error => {
+            console.error('CITY_LOCATIONS_ERROR:', error);
+            return [];
+          });
+      }
+      return cityLocations || [];
+    }
+
+    /*  Async function to find nearest city to user  */
+    let nearestCity = null;
+
+    const findNearestCity = (lat, lng) => {
+      return fetchCityLocations().then(cities => {
+        if (!cities || cities.length === 0) {
+          nearestCity = null;
+          return null;
+        }
+
+        let minDistance = Infinity;
+
+        cities.forEach(city => {
+          const distance = haversineDistanceKM(lat, lng, city.x, city.y);
+          if (distance < minDistance) {
+            minDistance = distance;
+            nearestCity = city;
+          }
+        });
+
+        console.log(`Nearest city to user: ${nearestCity ? nearestCity.name : 'None found'}`);
+        return nearestCity;
+      });
+    };
+
+    /* Request for user geolocation */
+    function geoFindUser() {
+      if (!navigator.geolocation) {
+        console.log('Geolocation is not supported by your browser');
+        return;
+      }
+      
+      async function success(pos) {
+        const lat = pos.coords.latitude;
+        const lng = pos.coords.longitude;
+        await findNearestCity(lat, lng);
+        console.log(`User's location: Latitude ${lat}, Longitude ${lng}`);
+      }
+
+      function error() {
+        console.log('Unable to retrieve your location');
+      }
+      navigator.geolocation.getCurrentPosition(success, error);
+
+    }
+
     /* ── boot ── */
     $(document).ready(function () {
 
+      geoFindUser();
       const isSsrRendered = weatherWidgetWrapper.length
         && weatherWidgetWrapper.children().length > 0
         && !$('.forecast-widget-skeleton').length;
@@ -361,7 +458,11 @@
       if (isSsrRendered) {
         initWeatherWidget(null);
       } else if (weatherWidgetWrapper.length && homeWeatherWidgetUrl) {
-        renderWeatherWidgetForCity();
+        if (nearestCity) {
+          renderWeatherWidgetForCity(nearestCity.slug);
+        } else {
+          renderWeatherWidgetForCity();
+        }
       } else {
         const forecastSkeleton = $('.forecast-widget-skeleton');
         if (forecastSkeleton.length) forecastSkeleton.hide();

--- a/climweb/src/climweb/pages/home/templates/home/home_page.html
+++ b/climweb/src/climweb/pages/home/templates/home/home_page.html
@@ -133,7 +133,6 @@
     <script>
     const homeMapSettingsUrl    = "{{ home_map_settings_url|default_if_none:'' }}";
     const homeWeatherWidgetUrl  = "{{ home_weather_widget_url|default_if_none:'' }}";
-    const cityLocationsUrl = "{{ city_locations_url|default_if_none:'' }}";
     const page_youtube_playlist = {{ page.youtube_playlist|yesno:'true,false' }};
     const citySearchUrl         = "{{ city_search_url }}";
     const cityDetailUrl         = "{{ city_detail_page_url|default_if_none:'' }}";
@@ -360,7 +359,7 @@
     /* Async function to call endpoint to fetch city locations from the backend, 
     returns a promise that resolves to an array of city locations */
     const fetchCityLocations = async () => {
-      if (!cityLocationsUrl) {
+      if (!citySearchUrl) {
         return [];
       }
 
@@ -370,7 +369,7 @@
 
       if (!cityLocations) {
         try {
-          const response = await fetch(cityLocationsUrl);
+          const response = await fetch(citySearchUrl);
           if (!response.ok) throw new Error('Error fetching city locations');
 
           const data = await response.json();

--- a/climweb/src/climweb/pages/home/templates/home/home_page.html
+++ b/climweb/src/climweb/pages/home/templates/home/home_page.html
@@ -354,7 +354,7 @@
     };
 
     /*  ── GEOLOCATION FOR NEAREST CITY TO USER  ── */
-    /* Function to calculate the distance between two points on Earth, using the Haversine formula */
+    /* Util Function to calculate the distance between two points on Earth, using the Haversine formula */
     function haversineDistanceKM(lat1Deg, lng1Deg, lat2Deg, lng2Deg) {
       function toRad(degree) {
           return degree * Math.PI / 180;
@@ -379,7 +379,8 @@
     }
   
 
-    /* Async function to fetch city locations from the backend, returns a promise that resolves to an array of city locations */
+    /* Async function to call endpoint to fetch city locations from the backend, 
+    returns a promise that resolves to an array of city locations */
     const fetchCityLocations = async () => {
       if (!weatherCityLocationsUrl) {
         return [];
@@ -424,54 +425,84 @@
           }
         });
         console.log(`Nearest city to user: ${nearestCity ? nearestCity.name : 'None found'}`);
-
-        renderWeatherWidgetForCity(nearestCity.slug)
         return nearestCity;
 
         
       });
     };
 
-    /* Request for user geolocation */
-    function geoFindUser() {
+    /* Request for user geolocation.
+      Returns a Promise resolving to the nearest city (or null) */
+    const geoFindUser = async () => {
       if (!navigator.geolocation) {
         console.log('Geolocation is not supported by your browser');
-        return;
-      }
-      
-      async function success(pos) {
-        const lat = pos.coords.latitude;
-        const lng = pos.coords.longitude;
-        await findNearestCity(lat, lng);
-        console.log(`User's location: Latitude ${lat}, Longitude ${lng}`);
+        return null;
       }
 
-      function error() {
-        console.log('Unable to retrieve your location');
-      }
-      navigator.geolocation.getCurrentPosition(success, error);
+      return new Promise((resolve) => {
+        async function success(pos) {
+          const lat = pos.coords.latitude;
+          const lng = pos.coords.longitude;
+          const city = await findNearestCity(lat, lng);
+          if (!city) {
+            console.log('No nearby city found for the user\'s location');
+          }
+          resolve(city);
+        }
 
-    }
+        function error() {
+          console.log('Unable to retrieve your location');
+          resolve(null);
+        }
+
+        navigator.geolocation.getCurrentPosition(success, error);
+      });
+    };
 
     /* ── boot ── */
     $(document).ready(function () {
 
-      geoFindUser();
-      const isSsrRendered = weatherWidgetWrapper.length
-        && weatherWidgetWrapper.children().length > 0
-        && !$('.forecast-widget-skeleton').length;
+      /* clicking the button always explicitly (re-)requests geolocation,
+         regardless of the auto-resolve logic below (delegated since the
+         button is re-rendered whenever the widget is re-fetched) */
+      weatherWidgetWrapper.on('click', '#use-my-location-btn', function () {
+        geoFindUser().then(city => {
+          if (city) renderWeatherWidgetForCity(city.slug);
+        });
+      });
 
-      if (isSsrRendered) {
-        initWeatherWidget(null);
-      } else if (weatherWidgetWrapper.length && homeWeatherWidgetUrl) {
-        if (nearestCity) {
-          renderWeatherWidgetForCity(nearestCity.slug);
-        } else {
+      const bootWeatherWidget = () => {
+        const isSsrRendered = weatherWidgetWrapper.length
+          && weatherWidgetWrapper.children().length > 0
+          && !$('.forecast-widget-skeleton').length;
+
+        if (isSsrRendered) {
+          initWeatherWidget(null);
+        } else if (weatherWidgetWrapper.length && homeWeatherWidgetUrl) {
           renderWeatherWidgetForCity();
+        } else {
+          const forecastSkeleton = $('.forecast-widget-skeleton');
+          if (forecastSkeleton.length) forecastSkeleton.hide();
         }
+      };
+
+      /* If geolocation permission was already granted on a previous visit, resolve it
+         up front and render straight to the nearest city - this skips
+         rendering the default city first and then re-rendering once the
+         position resolves. 
+       */
+      if (navigator.permissions && navigator.permissions.query) {
+        navigator.permissions.query({ name: 'geolocation' }).then(status => {
+          if (status.state === 'granted') {
+            geoFindUser().then(city => {
+              if (city) renderWeatherWidgetForCity(city.slug);
+            });
+          } else {
+            bootWeatherWidget();
+          }
+        }).catch(bootWeatherWidget);
       } else {
-        const forecastSkeleton = $('.forecast-widget-skeleton');
-        if (forecastSkeleton.length) forecastSkeleton.hide();
+        bootWeatherWidget();
       }
 
       if (page_youtube_playlist) {

--- a/climweb/src/climweb/pages/home/templates/home/home_page.html
+++ b/climweb/src/climweb/pages/home/templates/home/home_page.html
@@ -133,7 +133,7 @@
     <script>
     const homeMapSettingsUrl    = "{{ home_map_settings_url|default_if_none:'' }}";
     const homeWeatherWidgetUrl  = "{{ home_weather_widget_url|default_if_none:'' }}";
-    const weatherCityLocationsUrl = "{{ weather_city_locations_url|default_if_none:'' }}";
+    const cityLocationsUrl = "{{ city_locations_url|default_if_none:'' }}";
     const page_youtube_playlist = {{ page.youtube_playlist|yesno:'true,false' }};
     const citySearchUrl         = "{{ city_search_url }}";
     const cityDetailUrl         = "{{ city_detail_page_url|default_if_none:'' }}";
@@ -354,35 +354,13 @@
     };
 
     /*  ── GEOLOCATION FOR NEAREST CITY TO USER  ── */
-    /* Util Function to calculate the distance between two points on Earth, using the Haversine formula */
-    function haversineDistanceKM(lat1Deg, lng1Deg, lat2Deg, lng2Deg) {
-      function toRad(degree) {
-          return degree * Math.PI / 180;
-      }
-      
-      const lat1 = toRad(lat1Deg);
-      const lng1 = toRad(lng1Deg);
-      const lat2 = toRad(lat2Deg);
-      const lng2 = toRad(lng2Deg);
-      
-      const { sin, cos, sqrt, atan2 } = Math;
-      
-      const R = 6371; // earth radius in km 
-      const dLat = lat2 - lat1;
-      const dLon = lng2 - lng1;
-      const a = sin(dLat / 2) * sin(dLat / 2)
-              + cos(lat1) * cos(lat2)
-              * sin(dLon / 2) * sin(dLon / 2);
-      const c = 2 * atan2(sqrt(a), sqrt(1 - a)); 
-      const d = R * c;
-      return d; // distance in km
-    }
-  
+    /* Nearest city lookup is done with Turf.js (https://turfjs.org/) `nearestPoint`,
+       which expects GeoJSON points in [lng, lat] order. */
 
     /* Async function to call endpoint to fetch city locations from the backend, 
     returns a promise that resolves to an array of city locations */
     const fetchCityLocations = async () => {
-      if (!weatherCityLocationsUrl) {
+      if (!cityLocationsUrl) {
         return [];
       }
 
@@ -392,11 +370,14 @@
 
       if (!cityLocations) {
         try {
-          const response = await fetch(weatherCityLocationsUrl);
+          const response = await fetch(cityLocationsUrl);
           if (!response.ok) throw new Error('Error fetching city locations');
-          
+
           const data = await response.json();
-          cityLocations = Array.isArray(data.cities) ? data.cities : [];
+          /* cities-list returns a plain array of
+             { id, name, slug, coordinates: [lng, lat] } */
+          cityLocations = Array.isArray(data) ? data : [];
+          console.log('city data:', data);
         } catch (error) {
           console.error('CITY_LOCATIONS_ERROR:', error);
           return [];
@@ -415,19 +396,16 @@
           return null;
         }
 
-        let minDistance = Infinity;
+        const userPoint  = turf.point([lng, lat]);
+        const cityPoints = turf.featureCollection(
+          cities.map(city => turf.point(city.coordinates, { city }))
+        );
 
-        cities.forEach(city => {
-          const distance = haversineDistanceKM(lat, lng, city.lat, city.lng);
-          if (distance < minDistance) {
-            minDistance = distance;
-            nearestCity = city;
-          }
-        });
+        const nearest = turf.nearestPoint(userPoint, cityPoints);
+        nearestCity = nearest ? nearest.properties.city : null;
+
         console.log(`Nearest city to user: ${nearestCity ? nearestCity.name : 'None found'}`);
         return nearestCity;
-
-        
       });
     };
 

--- a/climweb/src/climweb/pages/home/templates/home/home_page.html
+++ b/climweb/src/climweb/pages/home/templates/home/home_page.html
@@ -473,6 +473,7 @@
           if (status.state === 'granted') {
             geoFindUser().then(city => {
               if (city) renderWeatherWidgetForCity(city.slug);
+              else bootWeatherWidget();
             });
           } else {
             bootWeatherWidget();

--- a/climweb/src/climweb/pages/weather/templates/weather/widgets/location_forecast_multiple_slider.html
+++ b/climweb/src/climweb/pages/weather/templates/weather/widgets/location_forecast_multiple_slider.html
@@ -19,6 +19,10 @@
           <span class="cf-detail-icon">{% svg_icon "info-circle" %}</span>
         </a>
       {% endif %}
+        <div class="cf-detail-btn" id="use-my-location-btn" >
+          <span class="is-hidden-mobile">{% translate "Use my location" %}</span>
+          <span class="cf-detail-icon">{% svg_icon "location" %}</span>
+        </div>
     </div>
 
     <div class="cf-search-wrap">

--- a/climweb/src/climweb/pages/weather/templates/weather/widgets/location_forecast_single_slider.html
+++ b/climweb/src/climweb/pages/weather/templates/weather/widgets/location_forecast_single_slider.html
@@ -18,6 +18,10 @@
           <span class="cf-detail-icon">{% svg_icon "info-circle" %}</span>
         </a>
       {% endif %}
+        <div class="cf-detail-btn" id="use-my-location-btn" >
+          <span class="is-hidden-mobile">{% translate "Use my location" %}</span>
+          <span class="cf-detail-icon">{% svg_icon "location" %}</span>
+        </div>
     </div>
 
     <div class="cf-search-wrap">

--- a/climweb/src/climweb/pages/weather/urls.py
+++ b/climweb/src/climweb/pages/weather/urls.py
@@ -1,10 +1,8 @@
 from django.urls import path
 
-from .views import get_home_forecast_widget, get_home_map_forecast, get_city_locations
+from .views import get_home_forecast_widget, get_home_map_forecast
 
 urlpatterns = [
     path('home-weather-widget/', get_home_forecast_widget, name="home-weather-widget"),
     path('home-weather-forecast/', get_home_map_forecast, name="home-weather-forecast"),
-    path('weather-city-locations/', get_city_locations, name="weather-city-locations"),
-
 ]

--- a/climweb/src/climweb/pages/weather/urls.py
+++ b/climweb/src/climweb/pages/weather/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from .views import get_home_forecast_widget, get_home_map_forecast
+from .views import get_home_forecast_widget, get_home_map_forecast, get_city_locations
 
 urlpatterns = [
     path('home-weather-widget/', get_home_forecast_widget, name="home-weather-widget"),
     path('home-weather-forecast/', get_home_map_forecast, name="home-weather-forecast"),
+    path('weather-city-locations/', get_city_locations, name="weather-city-locations"),
 
 ]

--- a/climweb/src/climweb/pages/weather/views.py
+++ b/climweb/src/climweb/pages/weather/views.py
@@ -137,21 +137,3 @@ def get_home_map_forecast(request):
     }
     
     return JsonResponse(res_data, safe=False)
-
-
-@require_GET
-def get_city_locations(request):
-    cities = City.objects.filter(location__isnull=False).order_by("name")
-    serialized_cities = CitySerializer(cities, many=True).data
-
-    city_data = [
-        {
-            "slug": city["slug"],
-            "name": city["name"],
-            "lat": city["coordinates"][1],
-            "lng": city["coordinates"][0],
-        }
-        for city in serialized_cities
-    ]
-
-    return JsonResponse({"cities": city_data}, safe=False)

--- a/climweb/src/climweb/pages/weather/views.py
+++ b/climweb/src/climweb/pages/weather/views.py
@@ -137,3 +137,20 @@ def get_home_map_forecast(request):
     }
     
     return JsonResponse(res_data, safe=False)
+
+
+@require_GET
+def get_city_locations(request):
+    cities = City.objects.filter(x__isnull=False, y__isnull=False).order_by("name")
+
+    city_data = [
+        {
+            "slug": city.slug,
+            "name": city.name,
+            "lng": city.x,
+            "lat": city.y,
+        }
+        for city in cities
+    ]
+
+    return JsonResponse({"cities": city_data}, safe=False)

--- a/climweb/src/climweb/pages/weather/views.py
+++ b/climweb/src/climweb/pages/weather/views.py
@@ -7,7 +7,7 @@ from django.views.decorators.http import require_GET
 from django.template.loader import render_to_string
 from forecastmanager.forecast_settings import ForecastSetting
 from forecastmanager.models import City, Forecast
-from forecastmanager.serializers import ForecastSerializer
+from forecastmanager.serializers import CitySerializer, ForecastSerializer
 from wagtail.api.v2.utils import get_full_url
 from wagtailcache.settings import wagtailcache_settings
 
@@ -141,16 +141,17 @@ def get_home_map_forecast(request):
 
 @require_GET
 def get_city_locations(request):
-    cities = City.objects.filter(x__isnull=False, y__isnull=False).order_by("name")
+    cities = City.objects.filter(location__isnull=False).order_by("name")
+    serialized_cities = CitySerializer(cities, many=True).data
 
     city_data = [
         {
-            "slug": city.slug,
-            "name": city.name,
-            "lng": city.x,
-            "lat": city.y,
+            "slug": city["slug"],
+            "name": city["name"],
+            "lat": city["coordinates"][1],
+            "lng": city["coordinates"][0],
         }
-        for city in cities
+        for city in serialized_cities
     ]
 
     return JsonResponse({"cities": city_data}, safe=False)


### PR DESCRIPTION
Added logic to support using user geolocation to fetch the nearest city available in Climweb’s forecasted cities to the user, and display the homepage weather widget of that respective city.

Closes #354

### Changes
~~- Added an API endpoint “…weather/weather-city-locations/” that returns all available forecasted cities with their latitude and longitude~~
- Added a ‘Use my location’ button on homepage
    - Users will be prompted to allow location access only upon clicking this button
    - Call API endpoint “../api/cities” to obtain all available forecasted cities
    - The nearest city (from the available forecasted cities) to the user (based on Turf.js’ `nearestPoint` function) will be found
    - `renderWeatherWidgetForCity(nearestCity.slug)` will be called with this nearest city
    - Weather widget will be re-rendered with the nearest city
- If users have previously granted access, the home page will load with the nearest city on future entries.

#### Example Flow
<img width="1432" height="468" alt="image" src="https://github.com/user-attachments/assets/8c935308-2658-4113-a35a-7bfae4a8b3a6" />
<img width="241" height="194" alt="image" src="https://github.com/user-attachments/assets/df2e0d74-7979-4c70-ab23-328e38cd6699" />
<img width="1440" height="469" alt="image" src="https://github.com/user-attachments/assets/e18b1799-2be9-4f76-8d76-6670fd5d672f" />
