### PR TITLE
Fix staff bio text overflowing modal box on scroll

### DIFF
--- a/climweb/src/climweb/pages/organisation_pages/staff/templates/staff/staff_page.html
+++ b/climweb/src/climweb/pages/organisation_pages/staff/templates/staff/staff_page.html
@@ -14,6 +14,19 @@
         .staff-role {
             text-transform: uppercase;
         }
+
+        /* Make the whole modal box scroll as one unit, so the white
+           background always follows the content shown on screen instead
+           of the bio text overflowing onto the dark modal backdrop. */
+        .staff-modal-content {
+            overflow: visible !important;
+            max-height: none !important;
+        }
+
+        .staff-modal-content .box {
+            max-height: 80vh;
+            overflow-y: auto;
+        }
     </style>
 
 {% endblock extra_css %}
@@ -81,7 +94,7 @@
                                                            style="font-size:12px">{{ staffmember.role }}</p>
                                                         <hr>
                                                         {% if staffmember.bio %}
-                                                            <div style="max-height:20rem">
+                                                            <div>
                                                                 <p>{{ staffmember.bio|richtext }}</p></div>
                                                         {% endif %}
                                                     </div>


### PR DESCRIPTION
The bio text container had a fixed max-height with no overflow rule, while  the parent modal box didn't scroll or constrain its own height. Scrolling  the bio text exposed content beyond the box's rendered height, causing it  to appear over the dark modal backdrop.

Fix: make the whole modal box scroll as a single unit (capped at 80vh)  instead of just the inner bio text.