### PR TITLE
fix(ai_settings): import register_setting so register_ai_setting doesn't NameError

### DIFF
--- a/climweb/src/climweb/base/models/ai_settings.py
+++ b/climweb/src/climweb/base/models/ai_settings.py
@@ -21,6 +21,7 @@ from django.conf import settings
 from wagtail.admin.forms import WagtailAdminModelForm
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel, ObjectList, TabbedInterface
 from wagtail.contrib.settings.models import BaseSiteSetting
+from wagtail.contrib.settings.registry import register_setting
 
 from climweb.base.backups.crypto import decrypt_text, encrypt_text
 


### PR DESCRIPTION
### Problem

`climweb/src/climweb/base/models/ai_settings.py` defines a helper that registers the AI settings
panel only when the AI switch is on:

```python
def register_ai_setting(cls):
    ...
    if getattr(settings, "WAGTAIL_AI_ENABLED", False):
        return register_setting(icon="wand")(cls)
    return cls
```

`register_setting` is never imported in this module. The module imports
`from wagtail.contrib.settings.models import BaseSiteSetting`, but not the `registry` symbol, so
with `WAGTAIL_AI_ENABLED` truthy the helper raises:

```
NameError: name 'register_setting' is not defined
```

The `else` path (`return cls`) is what runs today, which is why the module still imports cleanly —
the failure is latent and only surfaces the moment the AI assistant is reinstated, i.e. exactly the
path this dormant module is being kept for.

### Spec for the fix

Five sibling modules in this repo already import the symbol the same way, so there is no ambiguity
about the correct import:

| file | line |
|---|---|
| `climweb/base/models/backup_settings.py` | 33 |
| `climweb/base/models/cap_settings.py` | 9 |
| `climweb/base/models/site_settings.py` | 19 |
| `climweb/pages/home/models.py` | 18 |
| `climweb/pages/satellite_imagery/models.py` | 15 |

All five use `from wagtail.contrib.settings.registry import register_setting`, and call it in the
same decorator-factory form (`@register_setting(icon="download")` in `backup_settings.py:153`).

### Change

One added import line. No behaviour change on the current (AI-disabled) path.

```diff
 from wagtail.contrib.settings.models import BaseSiteSetting
+from wagtail.contrib.settings.registry import register_setting
```

### Verification

Replayed `register_ai_setting` from the file's own AST with `WAGTAIL_AI_ENABLED = True` and stubs
for `settings` / `register_setting`, before and after the change:

```
BEFORE (as on main): NameError: name 'register_setting' is not defined
AFTER  (import added): ('REGISTERED', 'wand', <class 'Dummy'>)
```

I deliberately did **not** delete the helper: the module docstring states the model and its wiring
are *deliberately* kept so migrations 0048/0049 stay valid, so restoring the helper to a working
state seemed truer to the file's stated intent than removing it. Happy to switch to removal instead
if you'd rather prune it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
